### PR TITLE
Set projects as landing page and show terminal help every launch

### DIFF
--- a/src/components/Default.jsx
+++ b/src/components/Default.jsx
@@ -57,9 +57,11 @@ const Default = props => {
 	return (
 		<>
 			<MenuContent programName={props.programName} />
-			<AlertContent
-				type={pathname.includes("qemu") ? `qemu` : `hideHelp`}
-			/>
+{(props.programName === "Terminal" || pathname.includes("qemu")) && (
+<AlertContent
+type={pathname.includes("qemu") ? `qemu` : `hideHelp`}
+/>
+)}
 			<Wrapper>
 				<Draggable
 					bounds={{

--- a/src/elements/Alert/AlertContent.jsx
+++ b/src/elements/Alert/AlertContent.jsx
@@ -131,20 +131,18 @@ const AlertContent = ({ type }) => {
 		img.onload = () => setSource(things);
 		//eslint-disable-next-line
 	}, []);
-	useEffect(() => {
-		if (alertHidden) {
-			containerRef.current.classList.remove("showAlert");
-			localStorage.setItem(`alert__${type}`, true);
-		}
-		//eslint-disable-next-line
-	}, [alertHidden]);
-	useEffect(() => {
-		let help = localStorage.getItem(`alert__${type}`);
-		if (!help && source && !alertHidden) {
-			containerRef.current.classList.add("showAlert");
-		}
-		//eslint-disable-next-line
-	}, [source]);
+       useEffect(() => {
+               if (alertHidden) {
+                       containerRef.current.classList.remove("showAlert");
+               }
+               //eslint-disable-next-line
+       }, [alertHidden]);
+       useEffect(() => {
+               if (source && !alertHidden) {
+                       containerRef.current.classList.add("showAlert");
+               }
+               //eslint-disable-next-line
+       }, [source, alertHidden]);
 	useEffect(() => {
 		const startTime = new Date();
 		let shakeInterval = 15;

--- a/src/elements/Dock/DockContent.jsx
+++ b/src/elements/Dock/DockContent.jsx
@@ -16,27 +16,27 @@ const DockContent = () => {
 					<span></span>
 					<div className="dock-nav">
 						<ul>
-							<Link to="/">
-								<li
-									data-title="Home"
-									className="full-width-icon"
-								>
-									<img
-										src={TerminalIcon}
-										className="img-fluid"
-										alt="mac"
-									/>
-								</li>
-							</Link>
-								<Link to="/projects">
-									<li data-title="Projects">
-										<img
-											src={FinderIcon}
-											className="img-fluid"
-											alt="mac"
-										/>
-									</li>
-								</Link>
+<Link to="/terminal">
+<li
+data-title="Terminal"
+className="full-width-icon"
+>
+<img
+src={TerminalIcon}
+className="img-fluid"
+alt="mac"
+/>
+</li>
+</Link>
+<Link to="/">
+<li data-title="Projects">
+<img
+src={FinderIcon}
+className="img-fluid"
+alt="mac"
+/>
+</li>
+</Link>
 							<div className="separator" />
 								<Link to="/resume">
 									<li data-title="Resume">

--- a/src/elements/Terminal/TerminalContent.jsx
+++ b/src/elements/Terminal/TerminalContent.jsx
@@ -94,14 +94,13 @@ const Label = styled.label`
 `;
 
 const InputLine = props => {
-	const [val, setVal] = useState("");
-	const { commands, setCommand, path } = useContext(DataContext);
-	const [counter, setCounter] = useState(commands.length);
-	const [typing, setTyping] = useState(false);
-	const [disabled, setDisabled] = useState(false);
-	const inputRef = useRef();
-	const cursorRef = useRef();
-	let alertHidden = localStorage.getItem("hideHelp");
+       const [val, setVal] = useState("");
+       const { commands, setCommand, path, alertHidden } = useContext(DataContext);
+       const [counter, setCounter] = useState(commands.length);
+       const [typing, setTyping] = useState(false);
+       const [disabled, setDisabled] = useState(false);
+       const inputRef = useRef();
+       const cursorRef = useRef();
 	useEffect(() => {
 		if (!disabled) {
 			inputRef.current.focus();
@@ -306,25 +305,31 @@ const Command = props => {
 };
 
 const TerminalContent = () => {
-	const [child, setChild] = useState(1);
-	const [active, setActive] = useState(true);
-	useEffect(() => {
-		setActive(true);
-	}, [active]);
-	return (
-		<BodyContent>
-			<Wrapper>
-				{Array.from(Array(child).keys()).map(i => (
-					<Command
-						setChild={setChild}
-						setActive={setActive}
-						child={child}
-						key={i === 0 ? active && i : i}
-					/>
-				))}
-			</Wrapper>
-		</BodyContent>
-	);
+       const [child, setChild] = useState(1);
+       const [active, setActive] = useState(true);
+       const { setAlertHidden } = useContext(DataContext);
+
+       useEffect(() => {
+               setAlertHidden(false);
+       }, [setAlertHidden]);
+
+       useEffect(() => {
+               setActive(true);
+       }, [active]);
+       return (
+               <BodyContent>
+                       <Wrapper>
+                               {Array.from(Array(child).keys()).map(i => (
+                                       <Command
+                                               setChild={setChild}
+                                               setActive={setActive}
+                                               child={child}
+                                               key={i === 0 ? active && i : i}
+                                       />
+                               ))}
+                       </Wrapper>
+               </BodyContent>
+       );
 };
 
 export default TerminalContent;

--- a/src/pages/Routes.jsx
+++ b/src/pages/Routes.jsx
@@ -12,19 +12,20 @@ import Contact from "@components/Contact";
 
 
 const Routes = () => {
-	return (
-        <Router basename={process.env.PUBLIC_URL}>
-			<Switch>
-				<Route path="/" exact component={Window} />
-				<Route path="/danger-zone" exact component={Danger} />
-				<Route path="/vscode" exact component={VSCode} />
-				<Route path="/resume" exact component={Resume} />
-				<Route path="/git" exact component={Git} />
-				<Route path="/projects" exact component={Projects} />
-				<Route path="/contact" exact component={Contact} />
-			</Switch>
-		</Router>
-	);
+        return (
+       <Router basename={process.env.PUBLIC_URL}>
+                       <Switch>
+                               <Route path="/" exact component={Projects} />
+                               <Route path="/terminal" exact component={Window} />
+                               <Route path="/danger-zone" exact component={Danger} />
+                               <Route path="/vscode" exact component={VSCode} />
+                               <Route path="/resume" exact component={Resume} />
+                               <Route path="/git" exact component={Git} />
+                               <Route path="/projects" exact component={Projects} />
+                               <Route path="/contact" exact component={Contact} />
+                       </Switch>
+               </Router>
+        );
 };
 
 export default Routes;


### PR DESCRIPTION
## Summary
- Open the projects page by default and move the terminal to `/terminal`
- Reset terminal help notification each time the terminal opens
- Show help alert only in the terminal window and update dock links

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a5daf850048325b7b9f84b44108dab