### PR TITLE
Improve mobile usability of default window

### DIFF
--- a/src/components/Default.jsx
+++ b/src/components/Default.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import styled from "styled-components";
+import React, { useEffect, useState } from "react";
+import styled, { css } from "styled-components";
 import HeadingBar from "@elements/Window/HeadingBar";
 import Draggable from "react-draggable";
 import bg from "@static/techbg.png";
@@ -7,7 +7,6 @@ import theme from "../styles/theme";
 import AlertContent from "../elements/Alert/AlertContent";
 import DockContent from "../elements/Dock/DockContent";
 import MenuContent from "../elements/Menu/MenuContent";
-import { css } from "styled-components";
 import { useLocation } from "react-router-dom";
 
 const Wrapper = styled.div`
@@ -36,49 +35,67 @@ const emulatorDimensions = css`
 `;
 
 const Container = styled.div`
-	width: fit-content;
-	border-radius: 0.6rem 0.6rem 0.3rem 0.3rem;
-	box-shadow: ${theme.windowShadow} 0px 1px 4px;
-	resize: ${props => (props.resizable ? `both` : `none`)};
-	overflow: hidden;
-	${props => (!props.isEmulator ? dimensionConstraints : emulatorDimensions)}
-	backdrop-filter: blur(1rem);
-	background: ${theme.bodyBgWithOpacity};
-	${props => props.height && `height: ${props.height}`}
+        width: fit-content;
+        border-radius: 0.6rem 0.6rem 0.3rem 0.3rem;
+        box-shadow: ${theme.windowShadow} 0px 1px 4px;
+        resize: ${props => (props.resizable ? `both` : `none`)};
+        overflow: hidden;
+        ${props => (!props.isEmulator ? dimensionConstraints : emulatorDimensions)}
+        backdrop-filter: blur(1rem);
+        background: ${theme.bodyBgWithOpacity};
+        ${props => props.height && `height: ${props.height}`}
+        @media (max-width: 768px) {
+                width: 100%;
+                min-width: 100%;
+                max-width: 100%;
+                height: 100vh;
+                max-height: 100vh;
+                border-radius: 0;
+                resize: none;
+        }
 `;
 
 const Default = props => {
-	const { pathname } = useLocation();
-	let resizable = false;
-	if (props.resizable === undefined) {
-		resizable = true;
-	}
-	const BOUND = 512;
+        const { pathname } = useLocation();
+        const [isMobile, setIsMobile] = useState(false);
+
+        useEffect(() => {
+                const checkMobile = () => setIsMobile(window.innerWidth <= 768);
+                checkMobile();
+                window.addEventListener("resize", checkMobile);
+                return () => window.removeEventListener("resize", checkMobile);
+        }, []);
+        let resizable = false;
+        if (props.resizable === undefined) {
+                resizable = true;
+        }
+        const BOUND = 512;
 	return (
 		<>
 			<MenuContent programName={props.programName} />
 			<AlertContent
 				type={pathname.includes("qemu") ? `qemu` : `hideHelp`}
 			/>
-			<Wrapper>
-				<Draggable
-					bounds={{
-						top: -128,
-						left: -BOUND,
-						right: BOUND,
-						bottom: BOUND,
-					}}
-					handle=".heading-bar"
-				>
-					<Container
-						height={props.height}
-						resizable={resizable}
-						isEmulator={props.heading === "qemu"}
-						onContextMenu={e => {
-							!props.contextMenu && e.preventDefault();
-						}}
-					>
-						<HeadingBar
+                        <Wrapper>
+                                <Draggable
+                                        disabled={isMobile}
+                                        bounds={{
+                                                top: -128,
+                                                left: -BOUND,
+                                                right: BOUND,
+                                                bottom: BOUND,
+                                        }}
+                                        handle=".heading-bar"
+                                >
+                                        <Container
+                                                height={props.height}
+                                                resizable={resizable}
+                                                isEmulator={props.heading === "qemu"}
+                                                onContextMenu={e => {
+                                                        !props.contextMenu && e.preventDefault();
+                                                }}
+                                        >
+                                                <HeadingBar
 							altClassName="heading-bar"
 							heading={props.heading}
 						/>


### PR DESCRIPTION
## Summary
- enhance Default window component with media queries for full-screen layout on small devices
- disable draggable behavior on mobile and auto-detect viewport size

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a5db25159c8325b2018b12e5d88275